### PR TITLE
Extend transfermarkt bid time

### DIFF
--- a/Website/transfermarkt_bieten.php
+++ b/Website/transfermarkt_bieten.php
@@ -52,7 +52,7 @@ if ($loggedin == 1) {
 							$debugStr = '4';
 							if ($n3t3 < 2) { // nur 2 Transfers zwischen zwei Teams
 								$debugStr = '5';
-								$in1 = "UPDATE ".$prefix."transfermarkt SET betrag_highest = ".$gebot.", bieter_highest = '".$cookie_team."', gebote = gebote+1, ende = ende+60 WHERE spieler = '".$spieler_id."' AND betrag_highest < ".$gebot." AND ende > ".time();
+								$in1 = "UPDATE ".$prefix."transfermarkt SET betrag_highest = ".$gebot.", bieter_highest = '".$cookie_team."', gebote = gebote+1, ende = ende+180 WHERE spieler = '".$spieler_id."' AND betrag_highest < ".$gebot." AND ende > ".time();
 								$in2 = mysql_query($in1);
 								$transferLog1 = "INSERT INTO ".$prefix."transfers_gebote (spieler, datum, bieter, bieterIP, betrag) VALUES ('".$spieler_id."', ".time().", '".$cookie_team."', '".getUserIP()."', ".bigintval($gebot).")";
 								$transferLog2 = mysql_query($transferLog1);


### PR DESCRIPTION
Right now it is set to 60 seconds. The problem is that it gives you no time at all to react and make another offer. Changing it to 180 seconds give you enogh time to think if it really worth paying extra money for that player or just let it go.
