### PR TITLE
Social media share match

### DIFF
--- a/Website/spielbericht.php
+++ b/Website/spielbericht.php
@@ -110,7 +110,6 @@ echo '<div class="matchReport">';
 	echo '<span class="team teamRight">'.$sql3['team2'].'</span>';
 echo '</div>';
 ?>
-<?php if ($loggedin == 1) { ?>
 <?php
 if ($live_scoring_meldung != '') {
 	echo '<p style="text-align:right">';
@@ -307,12 +306,32 @@ if ($sql3['typ'] == 'Liga') {
 <?php
 $abstand_spiel_heute = time()-$sql3['datum'];
 if ($abstand_spiel_heute > -3600) { // wenn das Spiel ueberhaupt schon war dann Kommentare zeigen
+    echo '<p>
+    <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Facebook" target="_blank">
+        <img width="32" src="/images/brands/facebook-32.png" alt="Facebook">
+    </a>
+    <a href="https://twitter.com/share?url=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Twitter" target="_blank">
+        <img width="32" src="/images/brands/twitter-32.png" alt="Twitter">
+    </a>
+    <a href="https://plus.google.com/share?url=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Google Plus" target="_blank">
+        <img width="32" src="/images/brands/google-plus-32.png" alt="Google Plus">
+    </a></p>';
     echo '<h1>'._('Kommentar des Reporters');
     if ($live_scoring_meldung != '') { echo ' ('.$live_scoring_min_gespielt.'. Minute)'; }
     echo '</h1>';
     echo $kommentar_liste;
 }
 elseif ($live_scoring_spieltyp_laeuft == '') {
+	echo '<p>
+    <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Facebook" target="_blank">
+        <img width="32" src="/images/brands/facebook-32.png" alt="Facebook">
+    </a>
+    <a href="https://twitter.com/share?url=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Twitter" target="_blank">
+        <img width="32" src="/images/brands/twitter-32.png" alt="Twitter">
+    </a>
+    <a href="https://plus.google.com/share?url=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Google Plus" target="_blank">
+        <img width="32" src="/images/brands/google-plus-32.png" alt="Google Plus">
+    </a></p>';
 	echo '<h1>'._('Mögliche RKP-Veränderungen').'</h1>';
 	$ergebnisStrings = array('0:0', '1:0', '2:0', '3:0', '0:3', '0:2', '0:1');
 	echo '<table><thead><tr class="odd"><th scope="col">'._('Ergebnis').'</th><th scope="col">'.$sql3['team1'].' ('.round($eloTeam1).')</th><th scope="col">'.$sql3['team2'].' ('.round($eloTeam2).')</th></tr></thead><tbody>';
@@ -326,7 +345,4 @@ elseif ($live_scoring_spieltyp_laeuft == '') {
 	echo '</tbody></table>';
 }
 ?>
-<?php } else { ?>
-<p><?php echo _('Du musst angemeldet sein, um diese Seite aufrufen zu können!'); ?></p>
-<?php } ?>
 <?php include 'zz3.php'; ?>

--- a/Website/spielbericht.php
+++ b/Website/spielbericht.php
@@ -307,14 +307,14 @@ if ($sql3['typ'] == 'Liga') {
 $abstand_spiel_heute = time()-$sql3['datum'];
 if ($abstand_spiel_heute > -3600) { // wenn das Spiel ueberhaupt schon war dann Kommentare zeigen
     echo '<p>
-    <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Facebook" target="_blank">
-        <img width="32" src="/images/brands/facebook-32.png" alt="Facebook">
+    <a target="_blank" title="Facebook" href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2'.CONFIG_SITE_DOMAIN.'/spielbericht.php?id='.trim($_GET['id']).')">
+        <img alt="Facebook" src="/images/brands/facebook-32.png" width="32" />
     </a>
-    <a href="https://twitter.com/share?url=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Twitter" target="_blank">
-        <img width="32" src="/images/brands/twitter-32.png" alt="Twitter">
+    <a target="_blank" title="Twitter" href="https://twitter.com/share?url=http%3A%2F%2'.CONFIG_SITE_DOMAIN.'/spielbericht.php?id='.trim($_GET['id']).')">
+        <img alt="Twitter" src="/images/brands/twitter-32.png" width="32" />
     </a>
-    <a href="https://plus.google.com/share?url=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Google Plus" target="_blank">
-        <img width="32" src="/images/brands/google-plus-32.png" alt="Google Plus">
+    <a target="_blank" title="Google Plus" href="https://plus.google.com/share?url=http%3A%2F%2'.CONFIG_SITE_DOMAIN.'/spielbericht.php?id='.trim($_GET['id']).')">
+        <img alt="Google Plus" src="/images/brands/google-plus-32.png" width="32" />
     </a></p>';
     echo '<h1>'._('Kommentar des Reporters');
     if ($live_scoring_meldung != '') { echo ' ('.$live_scoring_min_gespielt.'. Minute)'; }
@@ -323,14 +323,14 @@ if ($abstand_spiel_heute > -3600) { // wenn das Spiel ueberhaupt schon war dann 
 }
 elseif ($live_scoring_spieltyp_laeuft == '') {
 	echo '<p>
-    <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Facebook" target="_blank">
-        <img width="32" src="/images/brands/facebook-32.png" alt="Facebook">
+    <a target="_blank" title="Facebook" href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2'.CONFIG_SITE_DOMAIN.'/spielbericht.php?id='.trim($_GET['id']).')">
+        <img alt="Facebook" src="/images/brands/facebook-32.png" width="32" />
     </a>
-    <a href="https://twitter.com/share?url=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Twitter" target="_blank">
-        <img width="32" src="/images/brands/twitter-32.png" alt="Twitter">
+    <a target="_blank" title="Twitter" href="https://twitter.com/share?url=http%3A%2F%2'.CONFIG_SITE_DOMAIN.'/spielbericht.php?id='.trim($_GET['id']).')">
+        <img alt="Twitter" src="/images/brands/twitter-32.png" width="32" />
     </a>
-    <a href="https://plus.google.com/share?url=http%3A%2F%2Fwww.opensoccer.org%2F%3Fr%3D862eae52640f28975013b0b8e5ccdc70" title="Google Plus" target="_blank">
-        <img width="32" src="/images/brands/google-plus-32.png" alt="Google Plus">
+    <a target="_blank" title="Google Plus" href="https://plus.google.com/share?url=http%3A%2F%2'.CONFIG_SITE_DOMAIN.'/spielbericht.php?id='.trim($_GET['id']).')">
+        <img alt="Google Plus" src="/images/brands/google-plus-32.png" width="32" />
     </a></p>';
 	echo '<h1>'._('Mögliche RKP-Veränderungen').'</h1>';
 	$ergebnisStrings = array('0:0', '1:0', '2:0', '3:0', '0:3', '0:2', '0:1');


### PR DESCRIPTION
Here is an small update to allow players to share their matchs with friends.
Changes:

1. matches are public now (you dont need to login to see them)
2. social media buttons are now displayed after statistics

Pros: 
- You can share your match in facebook and show your friend how you destroyed him in a test match. Other people will see it and would like to join too. Everything is funnier with friends

Cons:
- Social icons could be a little intrusive and maybe annoying.

You could also check if the viewer is not logged in and display a pop out message saying something like "Are you part of OpenSoccer already? If not, JOIN NOW" or something like that.

![new-3](https://cloud.githubusercontent.com/assets/6611118/3774520/f2089b5c-192c-11e4-941f-be3b7a76f490.png)
