### PR TITLE
Match translation

### DIFF
--- a/Website/aa_spieltag_simulation.php
+++ b/Website/aa_spieltag_simulation.php
@@ -446,7 +446,8 @@ function kommentar($ersetzung, $typ) {
     );
 	if (isset($formulierungen[$typ])) { $formulierung = $formulierungen[$typ]; } else { return $typ; }
 	shuffle($formulierung);
-	$ausgabe = str_replace('XYZ', $ersetzung, $formulierung[0]);
+	$ersetzung = str_replace(' ','&',$ersetzung);
+	$ausgabe = str_replace('XYZ', '@'.$ersetzung, $formulierung[0]);
 	return $ausgabe;
 }
 function weakenTeam($team1Name, $defensivName, $cardType) {

--- a/Website/spielbericht.php
+++ b/Website/spielbericht.php
@@ -229,6 +229,41 @@ if ($ber2a > 0) {
         else {
             $minute_str = $ber3['minute'].'\': ';
         }
+        // ----- MATCH TRANSLATION STARTS -----
+        $translated = "";
+	$ausgabe2 = "";
+	if (strpos($ber3['kommentar'],'@') !== false) {
+		$str = explode(".",$ber3['kommentar']);
+		foreach($str as $key=>$sentence) {
+			if (strpos($sentence,'@') !== false) {
+				$str2 = explode(" ",$sentence);
+				foreach($str2 as $word) {
+					if (strpos($word,'@') !== false) {
+						$team_name = $word;
+					}
+				}
+				$ausgabe = str_replace( $team_name, 'XYZ', $sentence);
+				$ausgabe .= '.';
+			} else if (strpos($sentence,'[') !== true) {
+				$ausgabe = ltrim($sentence);
+				$ausgabe .= '.';
+			}
+			if ($key > 0) {
+				$ausgabe = _($ausgabe);
+				$ausgabe2 .= " ".$ausgabe;
+				$translated .= $ausgabe2;
+				$ausgabe2 = "";
+			} else {
+				$translated .= _($ausgabe);
+			}
+			$translated = str_replace( 'XYZ', substr($team_name, 1) , $translated);
+			$translated = str_replace('&',' ',$translated);
+		}
+		$ber3['kommentar'] = substr($translated, 0, -1);
+	} else {
+		$ber3['kommentar'] = _($ber3['kommentar']);
+	}
+	// ----- MATCH TRANSLATION ENDS -----
         $kommentar_ergebnis = extract_kommentar_ergebnis($ber3['kommentar']);
 		$kommentar_ergebnisStr = trim($kommentar_ergebnis[0]);
 		if (mb_substr($kommentar_ergebnisStr, 0, 9, 'UTF-8') == 'Noten für' OR mb_substr($kommentar_ergebnisStr, 0, 23, 'UTF-8') == '<strong>Die Zeitschrift') {


### PR DESCRIPTION
This is how I managed to translate matchs. It works in a "dynamic" way as you call it. It splits each sentence and translates it. It avoids ```eval()``` and everything is done after simulation is finished, so ```aa_spieltag_simulation.php``` is unnfected. Since it is a dynamic translation, it would only work for plain strings. In order to fix that, I added ```@``` before each team name, so it can recognize them.

Since this patch, all new matches will add an ```@``` before team name. ```@Sheffield&Athletic hat den Ball.``` and white spaces replaced with a ```&``` Old matches will be unaffected and not translated (you wont see the @ or & after the translation is done).

There wont be any problem with poedit here because phrases are already added (and some already translated). As I said, it translates from minute 1' to the end of the match. There are no bugs or cons.

This is probably not the best wa of doing it but maybe you can get a better idea from it.