### PR TITLE
Add menu scroll to mobile version

### DIFF
--- a/Website/images/Refresh.php
+++ b/Website/images/Refresh.php
@@ -556,7 +556,6 @@ tfoot th em {
 	text-align: center;
 	color: #fff;
 	background-color: #000;
-	border-bottom: 1px solid #666;
 	padding: 8px 2px;
 	font-size: 13px;
 	font-weight: bold;
@@ -831,7 +830,7 @@ div#sidebar-expander span {
         display: block;
     }
     div#sidebar-expander {
-        display: block;
+        display: flex;
     }
 }
 

--- a/Website/zz2.php
+++ b/Website/zz2.php
@@ -193,7 +193,9 @@ if ($_SESSION['last_ligaTausch_check'] < $vor3Minuten) {
 </ul>
 </div>
 <div id="content-wrap">
-<?php if ($loggedin == 1) { ?>
+<?php if ($loggedin == 1 && $_SESSION['via_android'] == 0) { ?>
+<script>var margin = 0; function ScrollMenu(left) { margin = margin + left; var nav = document.getElementById('nav'); nav.style.marginLeft = margin + 'px'; } </script>
+<div id="sidebar-expander"><span style="width:100%;" onClick="ScrollMenu(-50);"><?php echo _('<- slide menu'); ?></span><span style="width:100%;" onClick="ScrollMenu(50);"><?php echo _('slide menu ->'); ?></span></div>
 <div id="sidebar-expander" onclick="(function (self) { var sidebar = document.getElementById('sidebar'); self.style.display = 'none'; sidebar.style.display = 'block'; })(this);"><span><?php echo _('Seitenleiste ausklappen'); ?></span></div>
 <?php } ?>
 <?php if ($loggedin == 0) { ?>


### PR DESCRIPTION
I read in your forum that a guy with an iphone was angry becuase we removed to many features from the mobile version. He cant use the app, so I tought about adding a way to still select the other menu options on small devices.
I ended up with this. Maybe no really "cute" but it works. You can not view it in high resolution or android. 
I also removed the bottom border of the infobox. In mobile version, it was displaying an ugly line, while in full version you cant see it at all.

![new-2](https://cloud.githubusercontent.com/assets/6611118/7716262/889ac756-fe66-11e4-912a-ba43d70fc361.PNG)
